### PR TITLE
Added some changes and improvements. "yarn.lock" - needs to be rebuilt!

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/env", "@babel/react"]
+  "presets": ["@babel/env", "@babel/react"],
+  "plugins": ["transform-object-rest-spread"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,43 @@
 {
     "extends": "starnavi-react",
     "parserOptions": {
-      "ecmaVersion": 9
+      "ecmaVersion": 6,
+      "sourceType": "module",
+      "ecmaFeatures": {
+        "jsx": true,
+        "experimentalObjectRestSpread": true
+      }
     },
     "env": {
-      "browser": true
+      "browser": true,
+      "es6": true
+    },
+    "rules": {
+      "linebreak-style": [
+        "error",
+        "unix"
+      ],
+      "quotes": [
+        "error",
+        "single"
+      ],
+      "semi": [
+        "error",
+        "always"
+      ],
+      "comma-dangle": [
+        "error",
+        {
+          "arrays": "never",
+          "objects": "never",
+          "imports": "never",
+          "exports": "never",
+          "functions": "never"
+        }
+      ],
+      "func-names": [
+        "error",
+        "never"
+      ]
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,56 @@
+# npm packages #
 node_modules/
+
+# Dist files #
 dist/
-.idea
+
+# Yarn #
+yarn-error.log
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# jetBrains IDE #
+#################
+*.iml
+*.iws
+*.ipr
+.idea/
+
+# VSCode #
+.vscode/*

--- a/package.json
+++ b/package.json
@@ -4,17 +4,23 @@
   "description": "boilerplate with react, redux, styled-components, react-router",
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --mode development --open",
+    "start": "webpack-dev-server --mode development --hot",
     "build": "webpack --mode production",
     "test": "./node_modules/.bin/jest",
-    "lint": "./node_modules/.bin/eslint src/**"
+    "lint": "./node_modules/.bin/eslint 'src/**/*.@(js|jsx)' --ignore-path .eslintignore"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn run lint"
+    }
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/starnavi-team/react-app-boilerplate.git"
   },
   "author": "starnavi team",
-  "license": "ISC",
+  "license": "UNLICENSED",
+  "private": true,
   "bugs": {
     "url": "https://github.com/starnavi-team/react-app-boilerplate/issues"
   },
@@ -25,17 +31,20 @@
     "@babel/preset-react": "^7.0.0",
     "babel-jest": "^22.4.3",
     "babel-loader": "^8.0.2",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "css-loader": "^0.28.11",
     "enzyme": "^3.3.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-starnavi-react": "^1.0.0",
+    "eslint-loader": "^2.1.1",
     "eslint-plugin-import": "^2.11.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.7.0",
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
+    "husky": "^1.0.1",
     "image-webpack-loader": "^4.2.0",
     "jest": "^22.4.3",
     "mini-css-extract-plugin": "^0.4.0",
@@ -43,7 +52,7 @@
     "react-test-renderer": "^16.3.2",
     "redux-mock-store": "^1.5.1",
     "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14",
+    "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.3"
   },
   "dependencies": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -22,5 +22,5 @@ ReactDOM.render(
       </Switch>
     </BrowserRouter>
   </Provider>,
-  document.getElementById('root'),
+  document.getElementById('root')
 );

--- a/src/reducers/index.jsx
+++ b/src/reducers/index.jsx
@@ -3,5 +3,5 @@ import { combineReducers } from 'redux';
 import exampleReducer from './exampleReducer';
 
 export default combineReducers({
-  exampleReducer,
+  exampleReducer
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,13 @@
+const path = require("path");
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
+  entry: "./src/index.jsx",
+  output: {
+    filename: "main.js",
+    path: path.resolve(__dirname, "dist")
+  },
   resolve: {
     extensions: ['.js', '.jsx'],
   },
@@ -10,9 +16,10 @@ module.exports = {
       {
         test: /\.(js|jsx)$/,
         exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-        },
+        use: [
+          "babel-loader",
+          "eslint-loader"
+        ],
       },
       {
         test: /\.html$/,
@@ -52,7 +59,7 @@ module.exports = {
   plugins: [
     new HtmlWebPackPlugin({
       template: './src/index.html',
-      filename: './index.html',
+      filename: 'index.html',
     }),
     new MiniCssExtractPlugin({
       filename: '[name].css',


### PR DESCRIPTION
- Installed "babel-plugin-transform-object-rest-spread" for support of the "Object Rest/Spread".
- .gitignore: added more rules.
- .eslintrc.json: added changes and some rules.
- package.json: added some corrections, new packages were added "by hands" (therefore "yarn.lock" - needs to be rebuilt), made precommit linting and changed available scripts.
- Now webpack will lint js files, before passing them to babel-loader. Also made some changes in config, e.g. setted entry and output points.
- Added ".eslintignore".
- Setted new version of "webpack-cli". Usage of older version cause problems.